### PR TITLE
feat(ddtrace): disable telemetry collection by default

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -968,6 +968,20 @@ def mark_trace_as_error_for_5xx_responses(context, status_code, span):
             span.error = 1
 
 
+def disable_instrumentation_telemetry_by_default():
+    """
+    As of ddtrace v1.5 instrumentation telemetry collection is enabled by default. 
+    This feature can add 5-10% overhead to the tracer and increase cold start. 
+    Setting ``DD_INSTRUMENTATION_TELEMETRY_ENABLED=False`` will disable this feature.
+
+    Instrumentation Telemetry Collection is enabled when the first trace is sent to the
+    Agent. This feature must be disabled before tracing is configured.
+    """
+
+    if "DD_INSTRUMENTATION_TELEMETRY_ENABLED" not in os.environ:
+        os.environ["DD_INSTRUMENTATION_TELEMETRY_ENABLED"] = "false"
+
+
 class InferredSpanInfo(object):
     BASE_NAME = "_inferred_span"
     SYNCHRONICITY = f"{BASE_NAME}.synchronicity"

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -23,6 +23,7 @@ from datadog_lambda.module_name import modify_module_name
 from datadog_lambda.patch import patch_all
 from datadog_lambda.tracing import (
     extract_dd_trace_context,
+    disable_instrumentation_telemetry_by_default,
     create_dd_dummy_metadata_subsegment,
     inject_correlation_ids,
     dd_tracing_enabled,
@@ -136,6 +137,7 @@ class _LambdaDecorator(object):
             os.environ["DD_REQUESTS_SERVICE_NAME"] = os.environ.get(
                 "DD_SERVICE", "aws.lambda"
             )
+            disable_instrumentation_telemetry_by_default()
             # Patch third-party libraries for tracing
             patch_all()
 


### PR DESCRIPTION
### What does this PR do?

Disables `ddtrace` instrumentation telemetry data collection if the following environment variable is not set: `DD_INSTRUMENTATION_TELEMETRY_ENABLED=True`. This is done for performance reasons. This is required for `ddtrace>=1.5`.


### Motivation

Instrumentation Telemetry is designed to collect, transform and visualize usage, diagnostics and onboarding data for the various APM client libraries (tracer/profiler/debugger/appsec/etc.). The data collected and sent to the agent contains information about an application (dependencies, traced libraries, python versions and implementations, etc.), host/environment data (os, hostname, kernel, container id, etc.) and ddtrace configurations. Collecting this data in lambda functions can increase cold starts and the overhead of the tracer (initial tests show a 5-10% increase but this needs further verification).

Note - Enabling instrumentation telemetry is required for application security products.

### Types of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [ ] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [ ] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
